### PR TITLE
Feature/override init

### DIFF
--- a/ukcli/context.go
+++ b/ukcli/context.go
@@ -70,7 +70,7 @@ type Values struct {
 	MetaNames ukcore.SpecValue[[]string]
 	ArgRange  ukcore.SpecValue[uktodo.ArgRange]
 	FlagKind  ukcore.SpecValue[ukinput.FlagKind]
-	Initial   ukcore.SpecValue[[]string]
+	Initial   ukcore.SpecValue[any]
 	Info      ukcore.SpecValue[string]
 }
 

--- a/ukcli/runtime.go
+++ b/ukcli/runtime.go
@@ -73,7 +73,7 @@ var cfgBaseValues = Values{
 	MetaNames: ukvalue.DeriveTag("ukmeta", cfgTagFields),
 	ArgRange:  ukvalue.DeriveTag("ukarg", uktodo.ParseArgRange),
 	FlagKind:  ukvalue.DeriveField(cfgFlagKind),
-	Initial:   ukvalue.DeriveTag("ukinit", cfgTagFields),
+	Initial:   ukvalue.DeriveTag("ukinit", cfgTagInitial),
 	Info:      ukvalue.DeriveTag("ukinfo", cfgTagString),
 }
 
@@ -84,6 +84,10 @@ func cfgTagString(v string) (string, error) {
 func cfgTagFields(v string) ([]string, error) {
 	v = strings.TrimSpace(v)
 	return strings.Fields(v), nil
+}
+
+func cfgTagInitial(v string) (any, error) {
+	return cfgTagFields(v)
 }
 
 func cfgFlagKind(field ukcore.SpecField) (ukinput.FlagKind, error) {

--- a/ukcli/state.go
+++ b/ukcli/state.go
@@ -62,7 +62,7 @@ type StateOverrides struct {
 	MetaNames StateOverride[[]string]
 	ArgRange  StateOverride[uktodo.ArgRange]
 	FlagKind  StateOverride[ukinput.FlagKind]
-	Initial   StateOverride[[]string]
+	Initial   StateOverride[any]
 	Info      StateOverride[string]
 }
 

--- a/ukcli/ukdirect/operation.go
+++ b/ukcli/ukdirect/operation.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/oligarch316/ukase/ukcli"
 	"github.com/oligarch316/ukase/ukcore"
+	"github.com/oligarch316/ukase/ukcore/ukspec"
+	"github.com/oligarch316/ukase/ukcore/ukvalue"
 )
 
 // =============================================================================
@@ -77,4 +79,41 @@ func Handler[Params any](dec ukcli.Decoder, f func(context.Context, Params) erro
 
 		return f(ctx, params)
 	}
+}
+
+// -----------------------------------------------------------------------------
+// Default
+// -----------------------------------------------------------------------------
+
+type Default struct{ Params any }
+
+func (d Default) UkaseOperation(se *ukcli.StateEntry) error {
+	spec, err := ukspec.Of(d.Params)
+	if err != nil {
+		return err
+	}
+
+	paramsType := spec.Source()
+	paramsVal := reflect.ValueOf(d.Params)
+
+	keyPkg, keyName := paramsType.PkgPath(), paramsType.Name()
+
+	for field := range spec.Fields() {
+		fieldVal, err := paramsVal.FieldByIndexErr(field.Index)
+		if err != nil {
+			return err
+		}
+
+		if fieldVal.IsZero() {
+			continue
+		}
+
+		keyIndex := ukspec.FormatIndex(field.Index)
+		key := ukvalue.MapKey{Package: keyPkg, Name: keyName, Index: keyIndex}
+		val := fieldVal.Interface()
+
+		se.Overrides.Initial.Update(key, val)
+	}
+
+	return nil
 }

--- a/ukcore/ukparams/sink.go
+++ b/ukcore/ukparams/sink.go
@@ -39,15 +39,15 @@ func NewSink(v any) (Sink, error) {
 }
 
 // -----------------------------------------------------------------------------
-// Load
+// Read
 // -----------------------------------------------------------------------------
 
-func (s Sink) LoadField(index []int) (val reflect.Value, err error) {
-	defer s.recoverField(&err)
-	return s.loadField(s.Value, index), err
+func (s Sink) ReadField(index []int) (val reflect.Value, err error) {
+	defer s.readRecover(&err)
+	return s.readField(s.Value, index), err
 }
 
-func (Sink) loadField(val reflect.Value, index []int) reflect.Value {
+func (Sink) readField(val reflect.Value, index []int) reflect.Value {
 	for _, i := range index {
 		if val.Kind() == reflect.Pointer {
 			if val.IsZero() {
@@ -64,10 +64,59 @@ func (Sink) loadField(val reflect.Value, index []int) reflect.Value {
 	return val
 }
 
-func (Sink) recoverField(err *error) {
+func (Sink) readRecover(err *error) {
 	if recover() != nil {
 		*err = errors.New("[TODO Sink.recoverField] caught us a panic")
 	}
+}
+
+// -----------------------------------------------------------------------------
+// Write
+// -----------------------------------------------------------------------------
+
+// TODO:
+// This "Write" behavior is pretty specific to the `SourceInit` decoder.
+// As it stands, this logic should probably be moved under `SourceInit.Decode(...)`.
+
+func (s Sink) WriteField(index []int, v any) error {
+	dst, err := s.ReadField(index)
+	if err != nil {
+		return err
+	}
+
+	src := reflect.ValueOf(v)
+	return writeField(dst, src)
+}
+
+func writeField(dst, src reflect.Value) error {
+	if src.Type().AssignableTo(dst.Type()) {
+		dst.Set(src)
+		return nil
+	}
+
+	switch src.Kind() {
+	case reflect.String:
+		return writeFieldString(dst, src)
+	case reflect.Array, reflect.Slice:
+		return writeFieldSequence(dst, src)
+	}
+
+	return fmt.Errorf("[TODO writeField] incompatible destination (%s) and source (%s) values", dst.Kind(), src.Kind())
+}
+
+func writeFieldString(dst, src reflect.Value) error {
+	srcString := src.String()
+	return decodeField(dst, srcString)
+}
+
+func writeFieldSequence(dst, src reflect.Value) error {
+	for _, elem := range src.Seq2() {
+		if err := writeField(dst, elem); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // -----------------------------------------------------------------------------
@@ -75,7 +124,7 @@ func (Sink) recoverField(err *error) {
 // -----------------------------------------------------------------------------
 
 func (s Sink) DecodeField(index []int, srcs ...string) error {
-	dst, err := s.LoadField(index)
+	dst, err := s.ReadField(index)
 	if err != nil {
 		return err
 	}

--- a/ukcore/ukparams/source_init.go
+++ b/ukcore/ukparams/source_init.go
@@ -14,12 +14,12 @@ var _ Source = SourceInit{}
 // =============================================================================
 
 type SourceInit struct {
-	Initial ukcore.SpecValue[[]string]
+	Initial ukcore.SpecValue[any]
 }
 
 func (si SourceInit) Decode(sink Sink, _ ukcore.Input) error {
 	for field := range sink.Spec.Fields() {
-		if err := si.decodeField(sink, field.Index); err != nil {
+		if err := si.writeField(sink, field.Index); err != nil {
 			return err
 		}
 	}
@@ -27,13 +27,13 @@ func (si SourceInit) Decode(sink Sink, _ ukcore.Input) error {
 	return nil
 }
 
-func (si SourceInit) decodeField(sink Sink, index []int) error {
-	switch srcs, err := si.Initial.Load(sink.Spec, index); {
+func (si SourceInit) writeField(sink Sink, index []int) error {
+	switch src, err := si.Initial.Load(sink.Spec, index); {
 	case errors.Is(err, ukvalue.ErrNotSpecified):
 		return nil
 	case err != nil:
 		return err
 	default:
-		return sink.DecodeField(index, srcs...)
+		return sink.WriteField(index, src)
 	}
 }


### PR DESCRIPTION
Here we're doing the following:
1. Update "init" value logic to operate on `any` data in lieu of the previous `[]string` enforcement. This involves new non-string decoding logic under `ukparams` as well as updating the `SpecValue[...]` type parameter from `[]string` -to-> `any` everywhere applicable
2. Additional `Default` operation under `ukdirect`

Notably missing is any ergonomic finishing touch for easy use in client code. We're putting this off as the user api shape still feels pretty WIP